### PR TITLE
fix typo in usage README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,7 +30,7 @@ The gem that allows to localize your application.
 
     class UfoSeti < Padrino::Application
       ...
-      register Padrion::Localization::Urls
+      register Padrino::Localization::Urls
       ...
     end
 

--- a/lib/padrino-localization.rb
+++ b/lib/padrino-localization.rb
@@ -9,9 +9,12 @@ module Padrino
         app.helpers self
         app.extend ::Padrino::Localization::Urls::ClassMethods
         app.instance_eval do
-          alias :url_without_locale :url
-          alias :url :url_with_locale
-          alias :url_for :url_with_locale
+          unless @_padrino_localization_aliases_creadet
+            alias :url_without_locale :url
+            alias :url :url_with_locale
+            alias :url_for :url_with_locale
+          end
+          @_padrino_localization_aliases_creadet = true
         end
       end
 


### PR DESCRIPTION
Typo resulted in `'parent': wrong number of arguments (0 for 1) (ArgumentError)` error, which was hidden `"const_missing"`.
