### PR TITLE
fixed "stack level too deep" on padrino code autoreload

### DIFF
--- a/lib/padrino-localization.rb
+++ b/lib/padrino-localization.rb
@@ -9,9 +9,12 @@ module Padrino
         app.helpers self
         app.extend ::Padrino::Localization::Urls::ClassMethods
         app.instance_eval do
-          alias :url_without_locale :url
-          alias :url :url_with_locale
-          alias :url_for :url_with_locale
+          unless @_padrino_localization_aliases_creadet
+            alias :url_without_locale :url
+            alias :url :url_with_locale
+            alias :url_for :url_with_locale
+          end
+          @_padrino_localization_aliases_creadet = true
         end
       end
 


### PR DESCRIPTION
When you run development padrino server it autoreloads ruby code on
change. Problem is that aliase for `url_without_locale` is already in
place and now it creates infinite recursion.

This fixed recursion `url_with_locale` created by creating alliases
multiple times.
